### PR TITLE
Pom file updates

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>client</artifactId>
-    <name>Weather Monitor Client</name>
+    <name>Weather Monitor - Client</name>
 
     <packaging>jar</packaging>
 
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>com.pinorman.wx-mon</groupId>
             <artifactId>sensor-spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
@@ -26,7 +25,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.3.2</version>
                 <configuration>
                     <mainClass>com.pinorman.wxmon.client.WxClient</mainClass>
                     <arguments>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -18,14 +18,6 @@
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.12.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <schemaDirectory>src/main/xsd</schemaDirectory>
                     <schemaIncludes>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <sprint-boot.version>1.3.0.RELEASE</sprint-boot.version>
 
         <!-- raspberry pi -->
-        <pi4j.version>0.0.5</pi4j.version>
+        <pi4j.version>1.0</pi4j.version>
 
         <!-- logging -->
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.pinorman.wx-mon</groupId>
     <artifactId>parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>Weather Monitor Parent</name>
+    <name>Weather Monitor - Parent</name>
 
     <packaging>pom</packaging>
 
@@ -17,59 +17,248 @@
     </modules>
 
     <properties>
+        <!-- std -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+
+        <!-- spring -->
+        <spring-core.version>4.2.3.RELEASE</spring-core.version>
+        <sprint-boot.version>1.3.0.RELEASE</sprint-boot.version>
+
+        <!-- raspberry pi -->
+        <pi4j.version>0.0.5</pi4j.version>
+
+        <!-- logging -->
         <slf4j.version>1.7.7</slf4j.version>
-        <junit.version>4.11</junit.version>
         <logback.version>1.1.2</logback.version>
+
+        <!-- testing -->
+        <junit.version>4.12</junit.version>
+        <assertj.version>3.2.0</assertj.version>
+        <mockito.version>1.10.19</mockito.version>
+
+        <!-- other -->
+        <wagon.version>2.6</wagon.version>
+
+        <!-- plugins -->
+        <jaxb2-plugin.version>0.12.3</jaxb2-plugin.version>
+        <compiler-plugin.version>3.1</compiler-plugin.version>
+        <assembly-plugin.version>2.6</assembly-plugin.version>
+        <wagon-plugin.version>1.0</wagon-plugin.version>
+        <exec-plugin.version>1.3.2</exec-plugin.version>
+        <coveralls-plugin.version>2.2.0</coveralls-plugin.version>
+        <jacoco-plugin.version>0.7.1.201405082137</jacoco-plugin.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- modules -->
+            <dependency>
+                <groupId>com.pinorman.wx-mon</groupId>
+                <artifactId>sensor-spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- spring -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${sprint-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-tomcat</artifactId>
+                <version>${sprint-boot.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- raspberry pi -->
+            <dependency>
+                <groupId>com.pi4j</groupId>
+                <artifactId>pi4j-core</artifactId>
+                <version>${pi4j.version}</version>
+            </dependency>
+
+            <!-- logging -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+                <optional>true</optional>
+            </dependency>
+
+            <!-- testing -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <optional>true</optional>
         </dependency>
+
+        <!-- testing -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- generate -->
+                <plugin>
+                    <groupId>org.jvnet.jaxb2.maven2</groupId>
+                    <artifactId>maven-jaxb2-plugin</artifactId>
+                    <version>${jaxb2-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>generate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- compile -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${assembly-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- deploy -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>wagon-maven-plugin</artifactId>
+                    <version>${wagon-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.wagon</groupId>
+                            <artifactId>wagon-ssh</artifactId>
+                            <version>${wagon.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+                <!-- execution -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <configuration>
+                        <failOnMissingWebXml>false</failOnMissingWebXml>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${sprint-boot.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>repackage</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- testing -->
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>${coveralls-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>2.2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.1.201405082137</version>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/raspberry/pom.xml
+++ b/raspberry/pom.xml
@@ -22,12 +22,10 @@
         <dependency>
             <groupId>com.pinorman.wx-mon</groupId>
             <artifactId>sensor-spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-core</artifactId>
-            <version>${pi4j.version}</version>
         </dependency>
     </dependencies>
 
@@ -36,7 +34,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.3.2</version>
                 <configuration>
                     <mainClass>com.pinorman.wxmon.server.WxRaspiServer</mainClass>
                 </configuration>
@@ -52,14 +49,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <descriptors>
                                 <descriptor>src/main/assembly/pi4j.xml</descriptor>
@@ -77,14 +66,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>wagon-maven-plugin</artifactId>
-                        <version>1.0</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.maven.wagon</groupId>
-                                <artifactId>wagon-ssh</artifactId>
-                                <version>2.6</version>
-                            </dependency>
-                        </dependencies>
                         <executions>
                             <execution>
                                 <id>upload-jar</id>


### PR DESCRIPTION
I made a bunch of updates to the pom files.  Mostly revolving around dependency and plugin management.  This allows you to specify dependency and plugin versions in a common location (parent pom file) so the versions can be managed in a single location rather across multiple files.

Dependencies listed within the 'dependencyManagement' tag are not actually used until they are specified in the individual pom files.  Same goes for 'pluginManagement'.  So don't worry about dependencies or plugins you don't recognize.  We'll get to those later.  :smile: 
